### PR TITLE
Handle optional fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ import Button from "../components/Button";
 import Graph from "../components/Graph";
 
 const Article = ({ frontmatter, body }) => (
-  <MDXProvider components={[Button, Graph]}>
+  <MDXProvider components={{Button, Graph}}>
     <div>
       <h1>{frontmatter.title}</h1>
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -10,6 +10,9 @@ exports.createSchemaCustomization = ({
         resolve(source, args, context, info) {
           // Grab field
           const value = source[info.fieldName]
+          if (typeof value === 'undefined') {
+            return null;
+          }
           // Isolate MDX
           const mdxType = info.schema.getType('Mdx')
           // Grab just the body contents of what MDX generates


### PR DESCRIPTION
I'm working on a project and found your plugin. My MDX fields are optional in Netlify CMS.

I'm changing Gatsbys schema with 
```
...
body: String @mdx
...
```

that resulted in build error whenever the field was undefined
```
Error: TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type string or an instance of Buffer,
   TypedArray, or DataView. Received undefined
   ```

I managed to fix build errors with returning null. 
 